### PR TITLE
Wording review from CWG, Sat 15th Feb

### DIFF
--- a/D2825R5.html
+++ b/D2825R5.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2025-02-14" />
+  <meta name="dcterms.date" content="2025-02-15" />
   <title>Overload resolution hook: declcall( unevaluated-call-expression
 )</title>
   <style>
@@ -429,7 +429,7 @@ declcall( unevaluated-call-expression )</h1>
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2025-02-14</td>
+    <td>2025-02-15</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -515,7 +515,7 @@ well received, must come back</li>
 <li>Added core wording and got it reviewed, more revisions. Added
 devirtualized pointers to member functions.</li>
 <li>Expanded motivation section, resolved design question re.
-devirtualized pointers</li>
+devirtualized pointers, partial wording review from CWG</li>
 </ol>
 <h1 data-number="3" id="motivation-and-prior-art"><span class="header-section-number">3</span> Motivation and Prior Art<a href="#motivation-and-prior-art" class="self-link"></a></h1>
 <p>The language has currently no mechanism to take a pointer to a
@@ -640,8 +640,8 @@ similarly):</p>
 <span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> fptr_to_2 <span class="op">=</span> declcall<span class="op">(</span>f<span class="op">(</span><span class="dv">2</span><span class="bu">l</span><span class="op">))</span>;</span></code></pre></div>
 <p>The program is ill-formed if the named
 <code class="sourceCode default"><em>postfix-expression</em></code> is
-not a call to an addressable function (such as a constructor,
-destructor, built-in, etc.).</p>
+not a call to a function (such as a constructor, destructor, built-in,
+etc.).</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> S <span class="op">{}</span>;</span>
 <span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>declcall<span class="op">(</span>S<span class="op">())</span>; <span class="co">// Error, constructors are not addressable</span></span>
 <span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>declcall<span class="op">(</span><span class="fu">__builtin_unreachable</span><span class="op">())</span>; <span class="co">// Error, not addressable</span></span></code></pre></div>
@@ -1002,21 +1002,6 @@ so has EWG.</p>
         …<br />
         <code class="sourceCode default">alignof ( <em>type-id</em> )</code><br />
         <span class="add" style="color: #006e28"><ins><span><code class="sourceCode default">declcall ( <em>expression</em> )</code></span></ins></span></div>
-<p>Add to <span>7.7
-<a href="https://wg21.link/expr.const">[expr.const]</a></span>:</p>
-<p>We combine this into the
-<code class="sourceCode default">&amp;</code>-expression point because
-the footnote applies to both.</p>
-<blockquote>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized">(29.4)</a></span> an
-expression of the form
-<code class="sourceCode default">&amp; <em>cast-expression</em></code>
-<span class="add" style="color: #006e28"><ins>or
-<span><code class="sourceCode default">declcall ( <em>expression</em> )</code></span></ins></span>
-that occurs within a templated entity</li>
-</ul>
-</blockquote>
 <p>In <span>9.3.4.4
 <a href="https://wg21.link/dcl.mptr">[dcl.mptr]</a></span>, insert a new
 paragraph 5 after p4, and renumber section:</p>
@@ -1058,10 +1043,10 @@ change p2:</p>
 <p>… A pure virtual function need be defined only if called with, or as
 if with (<span>11.4.7
 <a href="https://wg21.link/class.dtor">[class.dtor]</a></span>), the
-qualified-id syntax (<span>7.5.5.3
-<a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>),
-or via a devirtualized pointer to member function (<span>9.3.4.4
-<a href="https://wg21.link/dcl.mptr">[dcl.mptr]</a></span>).</p>
+qualified-id syntax [<span>7.5.5.3
+<a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>][,
+or via a devirtualized pointer to member function
+([dcl.mptr]){.sref})]{.add}.</p>
 </blockquote>
 <p>Add new section under <span>7.6.2.6
 <a href="https://wg21.link/expr.alignof">[expr.alignof]</a></span>, with
@@ -1071,39 +1056,39 @@ a stable tag of <span class="add" style="color: #006e28"><ins>[expr.declcall]</i
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 The <code class="sourceCode default">declcall</code> operator yields a
-pointer prvalue to the function or member function which would be
-invoked by its <em>expression</em>. The operand of
+pointer prvalue to the function or a pointer to the member function
+which would be invoked by its <em>expression</em>. The operand of
 <code class="sourceCode default">declcall</code> is an unevaluated
 operand.</p>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
-If <em>expression</em> is not a function call (<span>7.6.1.3
-<a href="https://wg21.link/expr.call">[expr.call]</a></span>), but is an
-expression that is transformed into an equivalent function call
-(<span>12.2.2.3
-<a href="https://wg21.link/over.match.oper">[over.match.oper]</a></span>/2),
+If the <em>expression</em> is transformed into an equivalent function
+call (<span>12.2.2.3
+<a href="https://wg21.link/over.match.oper">[over.match.oper]</a></span>),
 replace <em>expression</em> by the transformed expression for the
-remainder of this subclause. Otherwise, the program is ill-formed. Such
-a (possibly transformed) <em>expression</em> is of the form
-<em>postfix-expression</em> ( <em>expression-list<sub>opt</sub></em> ).
+remainder of this subclause. If the <em>expression</em> is not a
+(possibly transformed) function call expression (<span>7.6.1.3
+<a href="https://wg21.link/expr.call">[expr.call]</a></span>), the
+program is ill-formed. Such a (possibly transformed) <em>expression</em>
+is of the form <em>postfix-expression</em> (
+<em>expression-list<sub>opt</sub></em> ).
 <!-- Jens says built-in operators aren't function calls and thus get taken out here. --></p>
 <p><span class="marginalizedparent"><a class="marginalized">3</a></span>
-If <em>postfix-expression</em> is a prvalue of pointer type
-<code class="sourceCode default">T</code> (<span>7.6.1.3
-<a href="https://wg21.link/expr.call">[expr.call]</a></span>/1), the
-result has type <code class="sourceCode default">T</code>, its value is
-unspecified, and the <code class="sourceCode default">declcall</code>
-expression shall not be potentially-evaluated.</p>
+If the <em>postfix-expression</em> is a prvalue of pointer type
+<code class="sourceCode default">T</code>, then the result has type
+<code class="sourceCode default">T</code> and the
+<code class="sourceCode default">declcall</code> expression shall not be
+potentially-evaluated.</p>
 <p><span class="marginalizedparent"><a class="marginalized">4</a></span>
-Otherwise, if <em>postfix-expression</em> is of the (possibly
+Otherwise, if the <em>postfix-expression</em> is of the (possibly
 transformed) form <code class="sourceCode default">E1 .* E2</code>
 (<span>7.6.4
 <a href="https://wg21.link/expr.mptr.oper">[expr.mptr.oper]</a></span>)
 where <code class="sourceCode default">E2</code> is a
 <em>cast-expression</em> of type
-<code class="sourceCode default">T</code>, the result has type
-<code class="sourceCode default">T</code>, its value is unspecified, and
-the <code class="sourceCode default">declcall</code> expression shall
-not be potentially-evaluated.</p>
+<code class="sourceCode default">T</code>, then the result has type
+<code class="sourceCode default">T</code> and the
+<code class="sourceCode default">declcall</code> expression shall not be
+potentially-evaluated.</p>
 <p><span class="marginalizedparent"><a class="marginalized">5</a></span>
 Otherwise, let <em>F</em> be the function selected by overload
 resolution (<span>12.2.2.2
@@ -1118,11 +1103,11 @@ and <code class="sourceCode default">T</code> its type.</p>
 is ill-formed.</p></li>
 <li><p><span class="marginalizedparent"><a class="marginalized">(5.2)</a></span>
 Otherwise, if <em>F</em> is a surrogate call function (<span>12.2.2.2.3
-<a href="https://wg21.link/over.call.object">[over.call.object]</a></span>/2),
-the result has type “pointer to
-<code class="sourceCode default">T</code>”, its value is unspecified,
-and the <code class="sourceCode default">declcall</code> expression
-shall not be potentially-evaluated.
+<a href="https://wg21.link/over.call.object">[over.call.object]</a></span>),
+then the result has type “pointer to
+<code class="sourceCode default">T</code>” and the
+<code class="sourceCode default">declcall</code> expression shall not be
+potentially-evaluated.
 <!-- this is to allow it in constant subexpressions where we only need the type --></p></li>
 <li><p><span class="marginalizedparent"><a class="marginalized">(5.3)</a></span>
 Otherwise, if <em>F</em> is an implicit object member function declared
@@ -1161,14 +1146,6 @@ Otherwise, the result has type “pointer to
 </blockquote>
 
 </div>
-<p>Into <span>13.8.3.4
-<a href="https://wg21.link/temp.dep.constexpr">[temp.dep.constexpr]</a></span>,
-add to list in 2.6:</p>
-<blockquote>
-<div class="line-block">    …<br />
-    <code class="sourceCode default">alignof ( <em>type-id</em> )</code><br />
-    <span class="add" style="color: #006e28"><ins><span><code class="sourceCode default">declcall ( <em>expression</em> )</code></span></ins></span></div>
-</blockquote>
 <p>Add feature-test macro into <span>17.3.2
 <a href="https://wg21.link/version.syn">[version.syn]</a></span> in
 section 2</p>

--- a/calltarget.md
+++ b/calltarget.md
@@ -32,7 +32,7 @@ In effect, `declcall` is a hook into the overload resolution machinery.
 2. `calltarget` was a bad name, and design refined
 3. Seen in EWG as `declcall`, well received, must come back
 4. Added core wording and got it reviewed, more revisions. Added devirtualized pointers to member functions.
-5. Expanded motivation section, resolved design question re. devirtualized pointers
+5. Expanded motivation section, resolved design question re. devirtualized pointers, partial wording review from CWG
 
 # Motivation and Prior Art
 
@@ -164,7 +164,7 @@ constexpr auto fptr_to_2 = declcall(f(2l));
 ```
 
 The program is ill-formed if the named `@_postfix-expression_@` is not a call
-to an addressable function (such as a constructor, destructor, built-in, etc.).
+to a function (such as a constructor, destructor, built-in, etc.).
 
 ```cpp
 struct S {};
@@ -564,13 +564,6 @@ In [expr.unary.general]{- .sref}
 |         `alignof ( @_type-id_@ )`
 |         [`declcall ( @_expression_@ )`]{.add}
 
-Add to [expr.const]{.sref}:
-
-We combine this into the `&`-expression point because the footnote applies to both.
-
-> - [29.4]{.pnum} an expression of the form `& @_cast-expression_@` [or `declcall ( @_expression_@ )`]{.add} that occurs within a templated entity
- 
-
 In [dcl.mptr]{- .sref}, insert a new paragraph 5 after p4, and renumber section:
 
 :::add
@@ -595,35 +588,31 @@ In [class.abstract]{.sref}, change p2:
 
 > ...
 > A pure virtual function need be defined only if called with, or as if with ([class.dtor]{.sref}),
-> the qualified-id syntax ([expr.prim.id.qual]{.sref}), or via a devirtualized pointer to member function ([dcl.mptr]{.sref}).
+> the qualified-id syntax [[expr.prim.id.qual]{.sref}][, or via a devirtualized pointer to member function ([dcl.mptr]){.sref})]{.add}.
 
 Add new section under [expr.alignof]{- .sref}, with a stable tag of [[expr.declcall]]{.add}.
 
 :::add
  
-> [1]{.pnum} The `declcall` operator yields a pointer prvalue to the function
-> or member function which would be invoked by its _expression_. The operand of
+> [1]{.pnum} The `declcall` operator yields a pointer prvalue to the function or a pointer to the member function which would be invoked by its _expression_. The operand of
 > `declcall` is an unevaluated operand.
-> 
-> [2]{.pnum} If _expression_ is not a function call ([expr.call]{- .sref}),
-> but is an expression that is transformed into an equivalent function call
-> ([over.match.oper]{.sref}/2), replace _expression_ by the transformed
+>
+> [2]{.pnum} If the _expression_ is transformed into an equivalent function call
+> ([over.match.oper]{.sref}), replace _expression_ by the transformed
 > expression for the remainder of this subclause.
-> Otherwise, the program is ill-formed.
+> If the _expression_ is not a (possibly transformed) function call expression ([expr.call]{.sref}), the program is ill-formed.
 > Such a (possibly transformed) _expression_ is of the form
 > _postfix-expression_ ( _expression-list~opt~_ ).
 > <!-- Jens says built-in operators aren't function calls and thus get taken out here. -->
-> 
-> [3]{.pnum} If _postfix-expression_ is a prvalue of pointer type `T` ([expr.call]{.sref}/1),
-> the result has type `T`,
-> its value is unspecified,
+>
+> [3]{.pnum} If the _postfix-expression_ is a prvalue of pointer type `T`,
+> then the result has type `T`
 > and the `declcall` expression shall not be potentially-evaluated.
 >
-> [4]{.pnum} Otherwise, if _postfix-expression_ is of the (possibly
+> [4]{.pnum} Otherwise, if the _postfix-expression_ is of the (possibly
 > transformed) form `E1 .* E2` ([expr.mptr.oper]{.sref})
-> where `E2` is a _cast-expression_ of type `T`,
-> the result has type `T`,
-> its value is unspecified,
+> where `E2` is a _cast-expression_ of type `T`, then
+> the result has type `T`
 > and the `declcall` expression shall not be potentially-evaluated.
 > 
 > [5]{.pnum} Otherwise, let _F_ be the function selected by overload resolution
@@ -633,9 +622,8 @@ Add new section under [expr.alignof]{- .sref}, with a stable tag of [[expr.declc
 >    ([expr.rel]{- .sref}, [expr.eq]{- .sref}),
 >    the program is ill-formed.
 >  - [5.2]{.pnum} Otherwise, if _F_ is a surrogate call function
->    ([over.call.object]{.sref}/2),
->    the result has type "pointer to `T`",
->    its value is unspecified,
+>    ([over.call.object]{.sref}),
+>    then the result has type "pointer to `T`"
 >    and the `declcall` expression shall not be potentially-evaluated.
 >    <!-- this is to allow it in constant subexpressions where we only need the type -->
 >  - [5.3]{.pnum} Otherwise, if _F_ is an implicit object member function
@@ -669,14 +657,7 @@ Add new section under [expr.alignof]{- .sref}, with a stable tag of [[expr.declc
 > - [5.4]{.pnum} Otherwise, the result has type "pointer to `T`" and points to _F_.
  
 :::
- 
-Into [temp.dep.constexpr]{.sref}, add to list in 2.6:
 
-> |     ...
-> |     `alignof ( @_type-id_@ )`
-> |     [`declcall ( @_expression_@ )`]{.add}
- 
- 
 Add feature-test macro into [version.syn]{.sref} in section 2
 
 :::add

--- a/generated/calltarget.html
+++ b/generated/calltarget.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2025-02-14" />
+  <meta name="dcterms.date" content="2025-02-15" />
   <title>Overload resolution hook: declcall( unevaluated-call-expression
 )</title>
   <style>
@@ -429,7 +429,7 @@ declcall( unevaluated-call-expression )</h1>
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2025-02-14</td>
+    <td>2025-02-15</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -515,7 +515,7 @@ well received, must come back</li>
 <li>Added core wording and got it reviewed, more revisions. Added
 devirtualized pointers to member functions.</li>
 <li>Expanded motivation section, resolved design question re.
-devirtualized pointers</li>
+devirtualized pointers, partial wording review from CWG</li>
 </ol>
 <h1 data-number="3" id="motivation-and-prior-art"><span class="header-section-number">3</span> Motivation and Prior Art<a href="#motivation-and-prior-art" class="self-link"></a></h1>
 <p>The language has currently no mechanism to take a pointer to a
@@ -640,8 +640,8 @@ similarly):</p>
 <span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> fptr_to_2 <span class="op">=</span> declcall<span class="op">(</span>f<span class="op">(</span><span class="dv">2</span><span class="bu">l</span><span class="op">))</span>;</span></code></pre></div>
 <p>The program is ill-formed if the named
 <code class="sourceCode default"><em>postfix-expression</em></code> is
-not a call to an addressable function (such as a constructor,
-destructor, built-in, etc.).</p>
+not a call to a function (such as a constructor, destructor, built-in,
+etc.).</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> S <span class="op">{}</span>;</span>
 <span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>declcall<span class="op">(</span>S<span class="op">())</span>; <span class="co">// Error, constructors are not addressable</span></span>
 <span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>declcall<span class="op">(</span><span class="fu">__builtin_unreachable</span><span class="op">())</span>; <span class="co">// Error, not addressable</span></span></code></pre></div>
@@ -1002,21 +1002,6 @@ so has EWG.</p>
         …<br />
         <code class="sourceCode default">alignof ( <em>type-id</em> )</code><br />
         <span class="add" style="color: #006e28"><ins><span><code class="sourceCode default">declcall ( <em>expression</em> )</code></span></ins></span></div>
-<p>Add to <span>7.7
-<a href="https://wg21.link/expr.const">[expr.const]</a></span>:</p>
-<p>We combine this into the
-<code class="sourceCode default">&amp;</code>-expression point because
-the footnote applies to both.</p>
-<blockquote>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized">(29.4)</a></span> an
-expression of the form
-<code class="sourceCode default">&amp; <em>cast-expression</em></code>
-<span class="add" style="color: #006e28"><ins>or
-<span><code class="sourceCode default">declcall ( <em>expression</em> )</code></span></ins></span>
-that occurs within a templated entity</li>
-</ul>
-</blockquote>
 <p>In <span>9.3.4.4
 <a href="https://wg21.link/dcl.mptr">[dcl.mptr]</a></span>, insert a new
 paragraph 5 after p4, and renumber section:</p>
@@ -1058,10 +1043,10 @@ change p2:</p>
 <p>… A pure virtual function need be defined only if called with, or as
 if with (<span>11.4.7
 <a href="https://wg21.link/class.dtor">[class.dtor]</a></span>), the
-qualified-id syntax (<span>7.5.5.3
-<a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>),
-or via a devirtualized pointer to member function (<span>9.3.4.4
-<a href="https://wg21.link/dcl.mptr">[dcl.mptr]</a></span>).</p>
+qualified-id syntax [<span>7.5.5.3
+<a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>][,
+or via a devirtualized pointer to member function
+([dcl.mptr]){.sref})]{.add}.</p>
 </blockquote>
 <p>Add new section under <span>7.6.2.6
 <a href="https://wg21.link/expr.alignof">[expr.alignof]</a></span>, with
@@ -1071,39 +1056,39 @@ a stable tag of <span class="add" style="color: #006e28"><ins>[expr.declcall]</i
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 The <code class="sourceCode default">declcall</code> operator yields a
-pointer prvalue to the function or member function which would be
-invoked by its <em>expression</em>. The operand of
+pointer prvalue to the function or a pointer to the member function
+which would be invoked by its <em>expression</em>. The operand of
 <code class="sourceCode default">declcall</code> is an unevaluated
 operand.</p>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
-If <em>expression</em> is not a function call (<span>7.6.1.3
-<a href="https://wg21.link/expr.call">[expr.call]</a></span>), but is an
-expression that is transformed into an equivalent function call
-(<span>12.2.2.3
-<a href="https://wg21.link/over.match.oper">[over.match.oper]</a></span>/2),
+If the <em>expression</em> is transformed into an equivalent function
+call (<span>12.2.2.3
+<a href="https://wg21.link/over.match.oper">[over.match.oper]</a></span>),
 replace <em>expression</em> by the transformed expression for the
-remainder of this subclause. Otherwise, the program is ill-formed. Such
-a (possibly transformed) <em>expression</em> is of the form
-<em>postfix-expression</em> ( <em>expression-list<sub>opt</sub></em> ).
+remainder of this subclause. If the <em>expression</em> is not a
+(possibly transformed) function call expression (<span>7.6.1.3
+<a href="https://wg21.link/expr.call">[expr.call]</a></span>), the
+program is ill-formed. Such a (possibly transformed) <em>expression</em>
+is of the form <em>postfix-expression</em> (
+<em>expression-list<sub>opt</sub></em> ).
 <!-- Jens says built-in operators aren't function calls and thus get taken out here. --></p>
 <p><span class="marginalizedparent"><a class="marginalized">3</a></span>
-If <em>postfix-expression</em> is a prvalue of pointer type
-<code class="sourceCode default">T</code> (<span>7.6.1.3
-<a href="https://wg21.link/expr.call">[expr.call]</a></span>/1), the
-result has type <code class="sourceCode default">T</code>, its value is
-unspecified, and the <code class="sourceCode default">declcall</code>
-expression shall not be potentially-evaluated.</p>
+If the <em>postfix-expression</em> is a prvalue of pointer type
+<code class="sourceCode default">T</code>, then the result has type
+<code class="sourceCode default">T</code> and the
+<code class="sourceCode default">declcall</code> expression shall not be
+potentially-evaluated.</p>
 <p><span class="marginalizedparent"><a class="marginalized">4</a></span>
-Otherwise, if <em>postfix-expression</em> is of the (possibly
+Otherwise, if the <em>postfix-expression</em> is of the (possibly
 transformed) form <code class="sourceCode default">E1 .* E2</code>
 (<span>7.6.4
 <a href="https://wg21.link/expr.mptr.oper">[expr.mptr.oper]</a></span>)
 where <code class="sourceCode default">E2</code> is a
 <em>cast-expression</em> of type
-<code class="sourceCode default">T</code>, the result has type
-<code class="sourceCode default">T</code>, its value is unspecified, and
-the <code class="sourceCode default">declcall</code> expression shall
-not be potentially-evaluated.</p>
+<code class="sourceCode default">T</code>, then the result has type
+<code class="sourceCode default">T</code> and the
+<code class="sourceCode default">declcall</code> expression shall not be
+potentially-evaluated.</p>
 <p><span class="marginalizedparent"><a class="marginalized">5</a></span>
 Otherwise, let <em>F</em> be the function selected by overload
 resolution (<span>12.2.2.2
@@ -1118,11 +1103,11 @@ and <code class="sourceCode default">T</code> its type.</p>
 is ill-formed.</p></li>
 <li><p><span class="marginalizedparent"><a class="marginalized">(5.2)</a></span>
 Otherwise, if <em>F</em> is a surrogate call function (<span>12.2.2.2.3
-<a href="https://wg21.link/over.call.object">[over.call.object]</a></span>/2),
-the result has type “pointer to
-<code class="sourceCode default">T</code>”, its value is unspecified,
-and the <code class="sourceCode default">declcall</code> expression
-shall not be potentially-evaluated.
+<a href="https://wg21.link/over.call.object">[over.call.object]</a></span>),
+then the result has type “pointer to
+<code class="sourceCode default">T</code>” and the
+<code class="sourceCode default">declcall</code> expression shall not be
+potentially-evaluated.
 <!-- this is to allow it in constant subexpressions where we only need the type --></p></li>
 <li><p><span class="marginalizedparent"><a class="marginalized">(5.3)</a></span>
 Otherwise, if <em>F</em> is an implicit object member function declared
@@ -1161,14 +1146,6 @@ Otherwise, the result has type “pointer to
 </blockquote>
 
 </div>
-<p>Into <span>13.8.3.4
-<a href="https://wg21.link/temp.dep.constexpr">[temp.dep.constexpr]</a></span>,
-add to list in 2.6:</p>
-<blockquote>
-<div class="line-block">    …<br />
-    <code class="sourceCode default">alignof ( <em>type-id</em> )</code><br />
-    <span class="add" style="color: #006e28"><ins><span><code class="sourceCode default">declcall ( <em>expression</em> )</code></span></ins></span></div>
-</blockquote>
 <p>Add feature-test macro into <span>17.3.2
 <a href="https://wg21.link/version.syn">[version.syn]</a></span> in
 section 2</p>


### PR DESCRIPTION
- removed 'its value is unspecified', not needed
- removed mention of 'addressable' for function, misleading
- removed addition to expr.const, not needed (Hubert)
- removed adition to temp.dep.constexpr, not needed, covered by existing rules (Jason)
- add "member function" explicitly in expr.declcall